### PR TITLE
Use older frame info syntax to support Python <=3.4

### DIFF
--- a/log/api.py
+++ b/log/api.py
@@ -46,14 +46,14 @@ warn = warning
 
 
 def _log(level, message, *args, **kwargs):
-    frame_info = inspect.stack()[3]
-    module = inspect.getmodule(frame_info.frame)
+    frame, filename, lineno, *_ = inspect.stack()[3]
+    module = inspect.getmodule(frame)
     logger = logging.getLogger()
     record = logger.makeRecord(
         module.__name__,
         level,
-        fn=frame_info.filename,
-        lno=frame_info.lineno,
+        fn=filename,
+        lno=lineno,
         msg=message,
         args=args,
         exc_info=None,


### PR DESCRIPTION
Fixes #2 