### PR TITLE
fix: added py.typed to inform of the existence of types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - RANDOM_SEED=0
 
 before_install:
-  - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+  - curl -sSL https://raw.githubusercontent.com/python-poetry/install.python-poetry.org/main/install-poetry.py | python -
   - make doctor
 
 install:


### PR DESCRIPTION
Fixes #52 

**BEFORE**

```
❯ poetry run mypy entrypoint.py
entrypoint.py:3: error: Skipping analyzing "log": module is installed, but missing library stubs or py.typed marker  [import]
entrypoint.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

**AFTER**

```
❯ touch /Users/sgarland/Library/Caches/pypoetry/virtualenvs/docker-proxysql-kjPLtdvK-py3.11/lib/python3.11/site-packages/log/py.typed
❯ poetry run mypy entrypoint.py
Success: no issues found in 1 source file
```